### PR TITLE
Fixed KillRunningJsReportProcesses on OSX

### DIFF
--- a/jsreport.Local/LocalReporting.cs
+++ b/jsreport.Local/LocalReporting.cs
@@ -57,7 +57,7 @@ namespace jsreport.Local
         {
             try
             {
-                Process.GetProcesses().ToList().Where(p => p.ProcessName == "jsreport").ToList().ForEach(p => p.Kill());
+                Process.GetProcesses().ToList().Where(p => p.ProcessName.Contains("jsreport").ToList().ForEach(p => p.Kill());
             } catch (Exception e)
             {
                 // avoid access denied errors


### PR DESCRIPTION
KillRunningJsReportProcesses is looking for an exact match for the process name. This fails on OSX as the binary has an .exe extension. Changing to Contains ensures the jsreporting servers are destroyed.